### PR TITLE
git clone https -> git clone git

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ There are four levels of increasing complexity for this example:
         In this tutorial we have done this for you.
 
         ```
-        git clone https://github.com/cms-opendata-analyses/HiggsExample20112012.git
+        git clone git://github.com/cms-opendata-analyses/HiggsExample20112012.git
         cd HiggsExample20112012/
         ls
         ```
@@ -210,7 +210,7 @@ There are four levels of increasing complexity for this example:
     
         ```
 
-        git clone https://github.com/cms-opendata-analyses/HiggsExample20112012.git
+        git clone git://github.com/cms-opendata-analyses/HiggsExample20112012.git
         ```
     - For this example, all active code and macros are present in the `HiggsExample20112012/Level3` directories. The analysis code in c++ that you will *run* is present in  `HiggsExample20112012/HiggsDemoAnalyzer` directory, and it will need to be compiled. You will also use the files in the `HiggsExample20112012/rootfiles` directory when making the final plot, similar to the Level2 tutorial.
         ```


### PR DESCRIPTION
Needed because https://githubengineering.com/crypto-removal-notice/
@fblekman pls have a look and merge, two occasions of git clone https:/... (now resulting to an error) changed to git clone git://... in readme